### PR TITLE
Fix publish dates

### DIFF
--- a/.github/workflows/create-link.yml
+++ b/.github/workflows/create-link.yml
@@ -47,11 +47,15 @@ jobs:
     needs: prepare_labels
     steps:
       - uses: actions/checkout@v3
+      - name: set current timestamp
+        id: current-timestamp
+        run: echo "TIMESTAMP=$(date +\"%Y-%m-%dT%H:%M:%S%z\")" >> $GITHUB_OUTPUT
       - name: log
         run: |
           echo "Create link PR ..."
           echo "\ttitle: ${{ inputs.title }}"
           echo "\tURL: ${{ inputs.url }}"
+          echo "\tdate: ${{ steps.current-timestamp.outputs.TIMESTAMP }}"
           echo "\ttags: ${{ inputs.tags }}"
           echo "\tcomment: ${{ inputs.comment }}"
           echo "\torigin title: ${{ inputs.origin_title }}"
@@ -61,7 +65,7 @@ jobs:
         with:
           node-version: 18.2.0
       - name: create post
-        run: node scripts/create-link.mjs --title="${{ inputs.title }}" --url=${{ inputs.url }} --date=${{ github.event.repository.updated_at }} --originTitle="${{ inputs.origin_title }}" --originUrl=${{ inputs.origin_url }} --comment="${{ inputs.comment }}" --publishedDate=${{ inputs.published_date }} --tags=${{ inputs.tags }}
+        run: node scripts/create-link.mjs --title="${{ inputs.title }}" --url=${{ inputs.url }} --date=${{ steps.current-timestamp.outputs.TIMESTAMP }} --originTitle="${{ inputs.origin_title }}" --originUrl=${{ inputs.origin_url }} --comment="${{ inputs.comment }}" --publishedDate=${{ inputs.published_date }} --tags=${{ inputs.tags }}
       - name: create PR
         uses: peter-evans/create-pull-request@v4
         with:

--- a/content/links/2023-03-09_simply-explained_-how-does-gpt-work_-_-confused-bi.md
+++ b/content/links/2023-03-09_simply-explained_-how-does-gpt-work_-_-confused-bi.md
@@ -1,6 +1,6 @@
 +++
 title = "Simply explained: how does GPT work? | Confused bit"
-date = 2023-03-09T00:29:14.000Z
+date = 2023-04-09T00:29:14.000Z
 template = "link.html"
 [taxonomies]
 tech=[]

--- a/content/links/2023-03-09_the-day-windows-died.md
+++ b/content/links/2023-03-09_the-day-windows-died.md
@@ -1,6 +1,6 @@
 +++
 title = "The Day Windows Died"
-date = 2023-03-09T00:29:14.000Z
+date = 2023-04-09T00:29:14.000Z
 template = "link.html"
 [taxonomies]
 tech=[]


### PR DESCRIPTION
The published dates were shifted by one month.

Revert to using "date" in workflow for creating links.