### PR TITLE
fix RSS feed generation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,7 @@ taxonomies = [
   { name = "tech" }
 ]
 
-generate_feed = true
+generate_feeds = true
 
 [markdown]
 # Whether to do syntax highlighting


### PR DESCRIPTION
Seems like newest Zola version drops `generate_feed` and uses `generate_feeds` instead. Let's hope this does not break existing feed.